### PR TITLE
Image does not match text

### DIFF
--- a/xfig-mod/3-10.eepic
+++ b/xfig-mod/3-10.eepic
@@ -30,9 +30,9 @@
 %  text 
 \put(2165,1997){\makebox(0,0)[lb]{\smash{{{\SetFigFont{9}{10.8}{\ttdefault}{\mddefault}{\updefault}...}}}}}
 %  text 
-\put(954,1747){\makebox(0,0)[lb]{\smash{{{\SetFigFont{10}{12.0}{\ttdefault}{\mddefault}{\updefault}W2:}}}}}
+\put(954,1747){\makebox(0,0)[lb]{\smash{{{\SetFigFont{10}{12.0}{\ttdefault}{\mddefault}{\updefault}W1:}}}}}
 %  text 
-\put(954,1497){\makebox(0,0)[lb]{\smash{{{\SetFigFont{10}{12.0}{\ttdefault}{\mddefault}{\updefault}W1:}}}}}
+\put(954,1497){\makebox(0,0)[lb]{\smash{{{\SetFigFont{10}{12.0}{\ttdefault}{\mddefault}{\updefault}W2:}}}}}
 %  text 
 \put(3600,912){\makebox(0,0)[lb]{\smash{{{\SetFigFont{10}{12.0}{\ttdefault}{\mddefault}{\updefault}balance: 100}}}}}
 %  text 


### PR DESCRIPTION
В тексте "Мы видим, что  W2 процедурный объект, то есть пара, содержащая код и окружение.
Окружение E2 для W2 было создано во время вызова  make-withdraw."
На картинке W2 связано с E1, а W1 связано с E2.
Просто поменял местами W1 и W2 на картинке.

Картинка:
![translate](https://user-images.githubusercontent.com/11513918/81461037-619c9480-91d3-11ea-8eb1-bfbdc1d17752.png)

Оригинал:
![orig](https://user-images.githubusercontent.com/11513918/81461046-6c572980-91d3-11ea-985a-696abdf83621.png)
 